### PR TITLE
회원가입 API 사용 중 /favicon.ico 로 redirect 되는 현상 발생

### DIFF
--- a/src/main/java/com/incense/gehasajang/security/SecurityConfig.java
+++ b/src/main/java/com/incense/gehasajang/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                .antMatchers("/*/*/signin", "/*/*/users/**", "/*/*/signout").permitAll()
+                .antMatchers("/*/*/signin", "/*/*/users/**", "/*/*/signout", "/favicon.ico").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/v1/terms", "/").permitAll()
                 .anyRequest().hasRole("SUB")
 


### PR DESCRIPTION
회원가입 API 사용 중 /favicon.ico 로 request가 가는 현상 발생
로그를 살펴보니 해당 /favicon.ico로 redirect 후 시큐리티에서 permision denied 발생

security 버그라는 글 발견

https://starplatina.tistory.com/entry/%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0%EC%97%90%EC%84%9C-faviconico%EB%A1%9C-redirect%EB%90%A0-%EB%95%8C

그래서 securit config에 /favicon.ico의 permision을 anonymous로 수정